### PR TITLE
fix: 移除 disk 配置，兼容 Render Free 计划

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,10 +15,6 @@ services:
       - key: API_KEY
         sync: false
       - key: GEMINI_COOKIE_PATH
-        value: /var/data/gemini_webapi
-    disks:
-      - name: gemini-cookie-cache
-        mountPath: /var/data/gemini_webapi
-        sizeGB: 1
+        value: /tmp/gemini_webapi
     healthCheckPath: /
     autoDeploy: true


### PR DESCRIPTION
Render Free 计划不支持 Persistent Disk，移除 disk 配置并改用 /tmp 存储 Cookie 缓存。功能不受影响，服务重启后会从环境变量重新加载 Cookie。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment configuration settings.

---

**Note:** This release contains infrastructure updates with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->