### PR TITLE
feat: split README for GitHub vs HuggingFace Space

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -14,9 +14,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Prepare Hugging Face README
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          cp README.hf.md README.md
+          git add README.md
+          git commit -m "Prepare Hugging Face Space README" || true
+
       - name: Push to Hugging Face Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           git remote add space https://zhiyu1998:${HF_TOKEN}@huggingface.co/spaces/zhiyu1998/Gemi2Api-Server
-          git push --force space main
+          git push --force space HEAD:main

--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-hf-space
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -20,11 +24,13 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           cp README.hf.md README.md
           git add README.md
-          git commit -m "Prepare Hugging Face Space README" || true
+          if ! git diff --cached --quiet; then
+            git commit -m "Prepare Hugging Face Space README"
+          fi
 
       - name: Push to Hugging Face Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           git remote add space https://zhiyu1998:${HF_TOKEN}@huggingface.co/spaces/zhiyu1998/Gemi2Api-Server
-          git push --force space HEAD:main
+          git push --force-with-lease space HEAD:main

--- a/README.hf.md
+++ b/README.hf.md
@@ -1,0 +1,39 @@
+---
+title: Gemi2Api Server
+emoji: 🚀
+colorFrom: blue
+colorTo: green
+sdk: docker
+app_port: 7860
+base_path: /admin
+pinned: false
+---
+
+# Gemi2Api Server
+
+一键部署到 [Hugging Face Space](https://huggingface.co/spaces/zhiyu1998/Gemi2Api-Server) 的 Gemini 网页版逆向代理。
+
+## 使用方法
+
+1. 点击 **Duplicate this Space** 创建你自己的副本
+2. 在 Space 设置中填入以下环境变量：
+   - `SECURE_1PSID` — Gemini Cookie 中的 `__Secure-1PSID`
+   - `SECURE_1PSIDTS` — Gemini Cookie 中的 `__Secure-1PSIDTS`
+   - `API_KEY`（可选）— 自定义 API 访问密钥
+3. Space 启动后访问 `/admin` 进入管理面板
+
+## 获取 Gemini Cookie
+
+1. 使用隐身标签访问 [Google Gemini](https://gemini.google.com/) 并登录
+2. 打开浏览器开发工具 (F12) → Application → Cookies → `gemini.google.com`
+3. 复制 `__Secure-1PSID` 和 `__Secure-1PSIDTS` 的值
+
+## API
+
+- `POST /v1/chat/completions` — OpenAI 兼容聊天接口
+- `GET /v1/models` — 可用模型列表
+- `GET /admin` — 管理面板
+
+## 文档
+
+完整文档请查看 [GitHub 仓库](https://github.com/zhiyu1998/Gemi2Api-Server)。

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
----
-title: Gemi2Api Server
-emoji: 🚀
-colorFrom: blue
-colorTo: green
-sdk: docker
-app_port: 7860
-pinned: false
----
-
 # Gemi2Api-Server
 [HanaokaYuzu / Gemini-API](https://github.com/HanaokaYuzu/Gemini-API) 的服务端简单实现
 
@@ -23,7 +13,7 @@ pinned: false
 
 ### HuggingFace
 
-[![Deploy to HuggingFace](https://img.shields.io/badge/%E7%82%B9%E5%87%BB%E9%83%A8%E7%BD%B2-%F0%9F%A4%97-fff)](https://huggingface.co/spaces/zhiyu1998/Gemi2Api-Server?duplicate=true)
+[![Deploy on Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-on-spaces-md.svg)](https://huggingface.co/new-space?duplicate=true&repo=zhiyu1998/Gemi2Api-Server)
 
 ## 直接运行
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ### HuggingFace
 
-[![Deploy on Spaces](https://huggingface.co/datasets/huggingface/badges/resolve/main/deploy-on-spaces-md.svg)](https://huggingface.co/new-space?duplicate=true&repo=zhiyu1998/Gemi2Api-Server)
+[![Follow us on HF](https://huggingface.co/datasets/huggingface/badges/resolve/main/follow-us-on-hf-lg-dark.svg)](https://huggingface.co/new-space?duplicate=true&repo=zhiyu1998/Gemi2Api-Server)
 
 ## 直接运行
 


### PR DESCRIPTION
## 改动

- **README.md**: 去掉 HF frontmatter（不再被 HF 误识别为 Space 配置），Deploy 按钮换成 [HF 官方徽章](https://huggingface.co/datasets/huggingface/badges)
- **README.hf.md**: 新建 HF Space 专用 README，包含 `sdk: docker`、`app_port: 7860`、`base_path: /admin` 等 frontmatter
- **workflow**: 推送前先 `cp README.hf.md → README.md`，GitHub 页面保持漂亮 README，HF Space 自动用专用版本

## 效果

| 平台 | README 来源 |
|------|------------|
| GitHub | `README.md`（无 frontmatter，正常展示） |
| Hugging Face Space | `README.hf.md`（带 Space 配置） |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Hugging Face Space documentation covering deployment, required env vars, admin panel access, and API endpoints
  * Updated main README and deployment badge to reflect Hugging Face workflow

* **Chores**
  * Improved deployment workflow: generates HF-compatible README during deploy, avoids duplicate in-progress runs, and ensures pushes use the intended branch target
<!-- end of auto-generated comment: release notes by coderabbit.ai -->