### PR TITLE
feat: admin panel integration + HOST/PORT env vars

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,11 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 from urllib.parse import quote, urlparse
 
+from dotenv import load_dotenv
+
+# 加载 .env 文件
+load_dotenv(Path(__file__).parent / ".env")
+
 import httpx
 import numpy as np
 from fastapi import Depends, FastAPI, Header, HTTPException, Request, Response
@@ -35,6 +40,10 @@ set_log_level("INFO")
 
 gemini_client = None
 gemini_client_lock = asyncio.Lock()
+
+# 服务配置（从环境变量读取，支持管理面板修改）
+HOST = os.environ.get("HOST", "0.0.0.0")
+PORT = int(os.environ.get("PORT", "7860"))
 
 
 async def _init_gemini_client_background():
@@ -71,6 +80,11 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Gemini API FastAPI Server", lifespan=lifespan)
+
+# 导入并集成管理面板
+from admin import router as admin_router, setup_middleware
+app.include_router(admin_router)
+setup_middleware(app)
 
 
 def get_gemini_webapi_version() -> str:
@@ -559,8 +573,10 @@ def map_model_name(openai_model_name: str) -> Model:
 		if normalized_openai_model_name in model_name.lower():
 			return m
 
-	# 如果找不到匹配项，使用默认映射
+	# 如果找不到匹配项，使用默认映射（兼容旧版和新版模型名称）
 	model_keywords = {
+		"gemini-3-pro": ["3", "pro"],
+		"gemini-3-flash": ["3", "flash"],
 		"gemini-pro": ["pro", "2.0"],
 		"gemini-pro-vision": ["vision", "pro"],
 		"gemini-flash": ["flash", "2.0"],
@@ -1121,4 +1137,4 @@ async def root():
 if __name__ == "__main__":
 	import uvicorn
 
-	uvicorn.run("main:app", host="0.0.0.0", port=7860, log_level="info")
+	uvicorn.run("main:app", host=HOST, port=PORT, log_level="info")

--- a/main.py
+++ b/main.py
@@ -41,9 +41,12 @@ set_log_level("INFO")
 gemini_client = None
 gemini_client_lock = asyncio.Lock()
 
-# 服务配置（从环境变量读取，支持管理面板修改）
+# 服务配置（从环境变量读取，修改后需重启服务生效）
 HOST = os.environ.get("HOST", "0.0.0.0")
-PORT = int(os.environ.get("PORT", "7860"))
+try:
+	PORT = int(os.environ.get("PORT", "7860"))
+except ValueError:
+	raise ValueError(f"Invalid PORT environment variable: '{os.environ.get('PORT')}' must be an integer")
 
 
 async def _init_gemini_client_background():
@@ -81,7 +84,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Gemini API FastAPI Server", lifespan=lifespan)
 
-# 导入并集成管理面板
+# 管理面板集成（必须在 app 初始化之后，admin.py 依赖 main 模块的配置和 app 实例）
 from admin import router as admin_router, setup_middleware
 app.include_router(admin_router)
 setup_middleware(app)
@@ -575,8 +578,8 @@ def map_model_name(openai_model_name: str) -> Model:
 
 	# 如果找不到匹配项，使用默认映射（兼容旧版和新版模型名称）
 	model_keywords = {
-		"gemini-3-pro": ["3", "pro"],
-		"gemini-3-flash": ["3", "flash"],
+		"gemini-3-pro": ["3.0", "pro"],
+		"gemini-3-flash": ["3.0", "flash"],
 		"gemini-pro": ["pro", "2.0"],
 		"gemini-pro-vision": ["vision", "pro"],
 		"gemini-flash": ["flash", "2.0"],


### PR DESCRIPTION
## 改动

```main.py (+18 -2)```

- **dotenv 加载**: 启动时自动读取 `.env` 文件
- **HOST/PORT 环境变量**: 默认 `0.0.0.0:7860`，支持通过环境变量覆盖
- **管理面板集成**: 挂载 admin router + CORS 中间件
- **Gemini 3 模型映射**: 支持 `gemini-3-pro`、`gemini-3-flash`
- **uvicorn.run**: 读取 HOST/PORT 变量而非硬编码

## 备注

`admin.py`、`templates/admin.html`、`Dockerfile`、`docker-compose.yml`、`render.yaml`、`README.hf.md` 等文件已在之前的 PR 中合并到 main，本次仅需集成 `main.py`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service host and port are now configurable through environment variables for flexible deployment
  * Environment variables are automatically loaded from a local configuration file at startup
  * Support for additional Gemini 3 model variants (Pro and Flash) is now available
  * Admin functionality has been integrated into the application
<!-- end of auto-generated comment: release notes by coderabbit.ai -->