### PR TITLE
fix: fetch HF remote before force-with-lease push

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -33,4 +33,5 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           git remote add space https://zhiyu1998:${HF_TOKEN}@huggingface.co/spaces/zhiyu1998/Gemi2Api-Server
+          git fetch space main || true
           git push --force-with-lease space HEAD:main


### PR DESCRIPTION
修复 `--force-with-lease` 报 `stale info` 的问题。

push 前先 `git fetch space main || true` 同步 HF 远端状态，首次部署 main 不存在时 `|| true` 跳过。