### PR TITLE
fix: admin panel quick test 401 - send auth header

### DIFF
--- a/main.py
+++ b/main.py
@@ -496,9 +496,7 @@ class ModelList(BaseModel):
 async def verify_api_key(authorization: str = Header(None)):
 	"""
 	Verify the API key extracted from the Authorization header.
-
-	Raises:
-		HTTPException: If the authorization header is missing, incorrectly formatted, or the token is invalid.
+	Also accepts valid admin session tokens for the quick test chat.
 	"""
 	if not API_KEY:
 		# If API_KEY is not set in environment, skip validation (for development)
@@ -506,6 +504,14 @@ async def verify_api_key(authorization: str = Header(None)):
 
 	if not authorization:
 		raise HTTPException(status_code=401, detail="Missing Authorization header")
+
+	# Accept valid admin session tokens (for admin panel quick test)
+	if authorization.startswith("Bearer "):
+		token = authorization[7:]
+		from admin import _admin_sessions, _clean_expired_sessions
+		_clean_expired_sessions()
+		if token in _admin_sessions:
+			return
 
 	try:
 		scheme, token = authorization.split()

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -895,11 +895,25 @@
                         stream: false
                     })
                 });
-                
-                const data = await res.json();
-                const reply = data.choices?.[0]?.message?.content || '抱歉，没有收到回复。';
-                
-                document.getElementById(loadingId).innerHTML = escapeHtml(reply);
+
+                if (!res.ok) {
+                    let errMsg;
+                    try {
+                        const errBody = await res.json();
+                        errMsg = errBody.error?.message || errBody.detail || JSON.stringify(errBody);
+                    } catch { errMsg = res.statusText || `HTTP ${res.status}`; }
+                    document.getElementById(loadingId).innerHTML = '';
+                    const span = document.createElement('span');
+                    span.style.color = '#f44336';
+                    span.textContent = `请求失败 (${res.status}): `;
+                    const el = document.getElementById(loadingId);
+                    el.appendChild(span);
+                    el.appendChild(document.createTextNode(errMsg));
+                } else {
+                    const data = await res.json();
+                    const reply = data.choices?.[0]?.message?.content || '抱歉，没有收到回复。';
+                    document.getElementById(loadingId).innerHTML = escapeHtml(reply);
+                }
             } catch (e) {
                 const el = document.getElementById(loadingId);
                 el.innerHTML = '<span style="color: #f44336;">错误: </span>';

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -885,7 +885,10 @@
             try {
                 const res = await fetch('/v1/chat/completions', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${adminToken}`
+                    },
                     body: JSON.stringify({
                         model: 'gemini-2.0-flash',
                         messages: [{ role: 'user', content: message }],


### PR DESCRIPTION
## 问题

管理面板快速测试聊天发送消息返回 401 Missing Authorization header。

## 原因

sendTestMessage 发请求时没带 Authorization header，被 verify_api_key 拒绝。

## 修复

- admin.html: 请求头加 Authorization: Bearer adminToken
- main.py: verify_api_key 额外接受有效的 admin session token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can authenticate requests using bearer session tokens in the Authorization header.
  * Admin panel test messaging now sends bearer tokens with requests and shows clearer error feedback when requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->