### PR TITLE
feat: model selector + fix version metadata crash

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -18,6 +18,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
+
+def _get_version() -> str:
+    try:
+        return importlib.metadata.version("gemi2api-server")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 # 创建路由器
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -227,7 +235,7 @@ async def get_status(token: str = Depends(verify_admin_token)):
 		"thinking_enabled": ENABLE_THINKING,
 		"temporary_chat": TEMPORARY_CHAT,
 		"auto_delete_chat": AUTO_DELETE_CHAT,
-		"version": importlib.metadata.version("gemi2api-server"),
+		"version": _get_version(),
 		"start_time": datetime.fromtimestamp(_start_time).strftime("%Y-%m-%d %H:%M:%S"),
 	}
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -477,6 +477,9 @@
                         <div class="chat-msg assistant">你好！我是 Gemini，有什么可以帮你的？</div>
                     </div>
                     <div class="chat-input">
+                        <select id="chatModel" style="background: #2a2a2a; color: #e0e0e0; border: 1px solid #444; border-radius: 6px; padding: 8px 12px; font-size: 14px; min-width: 180px;">
+                            <option value="">加载模型中...</option>
+                        </select>
                         <input type="text" id="chatInput" placeholder="输入消息..." onkeypress="if(event.key==='Enter')sendTestMessage()">
                         <button class="btn btn-primary" onclick="sendTestMessage()">发送</button>
                     </div>
@@ -663,8 +666,9 @@
             try {
                 const res = await fetch('/v1/models');
                 const data = await res.json();
-                
+
                 const list = document.getElementById('modelList');
+                const select = document.getElementById('chatModel');
                 if (data.data && data.data.length > 0) {
                     list.innerHTML = data.data.map(m => `
                         <div class="model-item">
@@ -672,8 +676,13 @@
                             <span style="color: #888;">${escapeHtml(m.owned_by)}</span>
                         </div>
                     `).join('');
+                    // 填充快速测试模型下拉框，过滤掉 'unspecified'
+                    const models = data.data.filter(m => m.id !== 'unspecified');
+                    select.innerHTML = models.map(m => `<option value="${escapeHtml(m.id)}">${escapeHtml(m.id)}</option>`).join('');
+                    if (select.options.length > 0) select.selectedIndex = 0;
                 } else {
                     list.innerHTML = '<div style="color: #666;">暂无可用模型</div>';
+                    select.innerHTML = '<option value="">无可用模型</option>';
                 }
             } catch (e) {
                 console.error('获取模型列表失败:', e);
@@ -883,6 +892,7 @@
             chatMessages.scrollTop = chatMessages.scrollHeight;
             
             try {
+                const model = document.getElementById('chatModel').value || 'gemini-3-flash';
                 const res = await fetch('/v1/chat/completions', {
                     method: 'POST',
                     headers: {
@@ -890,7 +900,7 @@
                         'Authorization': `Bearer ${adminToken}`
                     },
                     body: JSON.stringify({
-                        model: 'gemini-2.0-flash',
+                        model: model,
                         messages: [{ role: 'user', content: message }],
                         stream: false
                     })


### PR DESCRIPTION
## 改动内容

### 1. 快速测试添加模型选择器
- 在管理面板快速测试输入区添加模型选择下拉框
- 页面加载时自动从 `/v1/models` API 获取可用模型列表
- 过滤掉 `unspecified` 模型，只显示有效模型
- 默认使用列表中第一个模型，fallback 为 `gemini-3-flash`

### 2. 修复 status 接口 500 崩溃
- `importlib.metadata.version("gemi2api-server")` 在未安装包元数据时抛出 `PackageNotFoundError`，导致 `/admin/api/status` 返回 500
- 添加 `_get_version()` 辅助函数，捕获异常后返回 `"unknown"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a model selector dropdown to the admin quick-test chat, populated with available models and showing a “无可用模型” fallback when none are available.

* **Bug Fixes**
  * Status endpoint now reports a safe version value ("unknown") when package metadata is unavailable, preventing errors in status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->