### PR TITLE
✨ feat: 支持通过 DISABLE_BUILTIN_MODELS 禁用内置默认模型

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ SECURE_1PSID=your_psid_value_here
 SECURE_1PSIDTS=your_psidts_value_here
 API_KEY=Gemi2Api-Server
 CUSTOM_MODELS_FILE=
+DISABLE_BUILTIN_MODELS=false

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dev.ps1
 .trae/rules/git-commit-message.md
 AGENTS.md
 custom_models.yaml
+tests/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ TEMPORARY_CHAT = "false" # 使用临时对话模式，此模式会禁用部分�
 AUTO_DELETE_CHAT = "true" # 生成结束后自动从web端删除对话记录，默认开启。TEMPORARY_CHAT为true时，此项无效。
 PUBLIC_BASE_URL = "https://your-domain.com" # 外部URL，用于生成图片代理链接，不填则会使用内部地址。使用反向代理时必填，否则可能导致图片无法访问。
 CUSTOM_MODELS_FILE = "custom_models.yaml" # 可选。用于覆写/新增 Gemini 模型定义，支持 YAML/JSON。
+DISABLE_BUILTIN_MODELS = "false" # 可选。设为 true 时，/v1/models 仅返回 CUSTOM_MODELS(_FILE) 中定义的模型，不再追加 gemini_webapi 内置模型。
 ```
 
 `custom_models.yaml` 示例：

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ TEMPORARY_CHAT = "false" # 使用临时对话模式，此模式会禁用部分�
 AUTO_DELETE_CHAT = "true" # 生成结束后自动从web端删除对话记录，默认开启。TEMPORARY_CHAT为true时，此项无效。
 PUBLIC_BASE_URL = "https://your-domain.com" # 外部URL，用于生成图片代理链接，不填则会使用内部地址。使用反向代理时必填，否则可能导致图片无法访问。
 CUSTOM_MODELS_FILE = "custom_models.yaml" # 可选。用于覆写/新增 Gemini 模型定义，支持 YAML/JSON。
-DISABLE_BUILTIN_MODELS = "false" # 可选。设为 true 时，/v1/models 仅返回 CUSTOM_MODELS(_FILE) 中定义的模型，不再追加 gemini_webapi 内置模型。
+DISABLE_BUILTIN_MODELS = "false" # 可选。设为 true 时，/v1/models 仅返回 CUSTOM_MODELS(_FILE) 中定义的模型，不再追加 gemini_webapi 内置模型。此开关在服务启动时读取，修改 .env 后需重启生效（区别于 CUSTOM_MODELS_FILE 的免重启热加载）。
 ```
 
 `custom_models.yaml` 示例：

--- a/main.py
+++ b/main.py
@@ -157,6 +157,7 @@ SECURE_1PSIDTS = os.environ.get("SECURE_1PSIDTS", "")
 API_KEY = os.environ.get("API_KEY", "")
 ENABLE_THINKING = os.environ.get("ENABLE_THINKING", "false").lower() == "true"
 TEMPORARY_CHAT = os.environ.get("TEMPORARY_CHAT", "false").lower() == "true"
+DISABLE_BUILTIN_MODELS = os.environ.get("DISABLE_BUILTIN_MODELS", "false").lower() == "true"
 AUTO_DELETE_CHAT = os.environ.get("AUTO_DELETE_CHAT", "true").lower() == "true" and not TEMPORARY_CHAT
 PUBLIC_BASE_URL = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
 SECRET_FILE_PATH = os.path.join(os.path.dirname(__file__), "secrets", "proxy_secret")
@@ -638,6 +639,10 @@ async def list_models():
 				"owned_by": "google-gemini-web",
 			}
 		)
+
+	# 禁用内置模型时，仅返回自定义模型
+	if DISABLE_BUILTIN_MODELS:
+		return {"object": "list", "data": data}
 
 	for m in Model:
 		if m is Model.UNSPECIFIED:


### PR DESCRIPTION
## 概述

Closes #59

在配置了 `CUSTOM_MODELS` / `CUSTOM_MODELS_FILE` 后，新增 `DISABLE_BUILTIN_MODELS` 环境变量，用于在 `/v1/models` 中隐藏 `gemini_webapi` 内置模型，仅返回用户自定义的模型列表。

## 使用方式

```properties
CUSTOM_MODELS_FILE = "custom_models.yaml"
DISABLE_BUILTIN_MODELS = "true" # 默认 false。设为 true 时 /v1/models 仅返回自定义模型
```

## 实现说明

- `main.py`：新增 `DISABLE_BUILTIN_MODELS` 开关（与其他布尔开关一致，重启后生效）；`/v1/models` 在遍历自定义模型注册表后，若开关开启则直接返回，不再追加 `Model` 枚举中的内置模型
- `.env.example` / `README.md`：补充配置说明

## 行为说明

- 默认值 `false`，行为与之前完全一致（自定义模型 + 内置模型）
- `map_model_name()` 解析逻辑未改动：客户端从 `/v1/models` 拿到的自定义模型名可正常解析；手动传内置模型名请求 `/v1/chat/completions` 仍可用，只是不再出现在列表中

## 测试

TestClient 功能验证：

- `DISABLE_BUILTIN_MODELS=true` + 1 个自定义模型 → `/v1/models` 仅返回 `['my-custom-model']`
- `DISABLE_BUILTIN_MODELS=false`（默认）→ 返回自定义模型 + 9 个内置模型，与改动前一致

`ruff check` 无新增告警（存量 E402 与本次改动无关）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to hide built-in models from the `/v1/models` endpoint.
  * When enabled, only custom-configured models are listed; the default behavior remains unchanged.

* **Documentation**
  * Documented the `DISABLE_BUILTIN_MODELS` environment variable, its default value, and the requirement to restart the service after changing it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->